### PR TITLE
修改地图参数: ze_angels_of_death_b6f3

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_angels_of_death_b6f3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_angels_of_death_b6f3.cfg
@@ -23,7 +23,7 @@ mp_timelimit "25"
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
-mp_roundtime "20.0"
+mp_roundtime "40.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_angels_of_death_b6f3
## 为什么要增加/修改这个东西
触发时间不够，将地图回合时间调整为原图的40分钟
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
